### PR TITLE
Simple python bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,11 @@ target_include_directories(kafkaopmon_kafkaOpmonService_duneOpmonService PUBLIC)
 ##daq_add_application(kafka_opmon_consumer kafka_opmon_consumer.cxx LINK_LIBRARIES opmonlib::opmonlib RdKafka::rdkafka++ CURL::libcurl ers::ers ${CPR_LIBRARIES} ${Boost_PROGRAM_OPTIONS_LIBRARY})
 
 
+##############################################################################
+# Python bindings
+
+daq_add_python_bindings(*.cpp LINK_LIBRARIES ${PROJECT_NAME})
+
 
 ##############################################################################
 # No integration tests written

--- a/pybindsrc/module.cpp
+++ b/pybindsrc/module.cpp
@@ -1,0 +1,34 @@
+/**
+ * @file module.cpp. This performs python binding for the kafkaopmon package.
+ *
+ * This is part of the DUNE DAQ Software Suite, copyright 2022.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include "pybind11_json.hpp"
+#include <nlohmann/json.hpp>
+#include "JsonFlattener.hpp"
+
+
+namespace py = pybind11;
+
+namespace dunedaq {
+namespace kafkaopmon {
+namespace python {
+	
+
+PYBIND11_MODULE(_daq_kafkaopmon_py, module) {
+
+  py::class_<kafkaopmon::JsonFlattener>(module, "JsonFlattener")
+    // constructor 
+    .def(py::init<const nlohmann::json&>())
+    // methods
+    .def("get", &kafkaopmon::JsonFlattener::get);
+}
+
+} // namespace python
+} // namespace kafkaopmon
+} // namespace dunedaq

--- a/python/kafkaopmon/__init__.py
+++ b/python/kafkaopmon/__init__.py
@@ -1,0 +1,2 @@
+from ._daq_kafkaopmon_py import *
+

--- a/src/pybind11_json.hpp
+++ b/src/pybind11_json.hpp
@@ -1,0 +1,224 @@
+/***************************************************************************
+* Copyright (c) 2019, Martin Renou                                         *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef PYBIND11_JSON_HPP
+#define PYBIND11_JSON_HPP
+
+#include <string>
+#include <vector>
+
+#include "nlohmann/json.hpp"
+
+#include "pybind11/pybind11.h"
+
+namespace py = pybind11;
+namespace nl = nlohmann;
+
+namespace pyjson
+{
+    inline py::object from_json(const nl::json& j)
+    {
+        if (j.is_null())
+        {
+            return py::none();
+        }
+        else if (j.is_boolean())
+        {
+            return py::bool_(j.get<bool>());
+        }
+        else if (j.is_number_integer())
+        {
+            return py::int_(j.get<nl::json::number_integer_t>());
+        }
+        else if (j.is_number_unsigned())
+        {
+            return py::int_(j.get<nl::json::number_unsigned_t>());
+        }
+        else if (j.is_number_float())
+        {
+            return py::float_(j.get<double>());
+        }
+        else if (j.is_string())
+        {
+            return py::str(j.get<std::string>());
+        }
+        else if (j.is_array())
+        {
+            py::list obj(j.size());
+            for (std::size_t i = 0; i < j.size(); i++)
+            {
+                obj[i] = from_json(j[i]);
+            }
+            return std::move(obj);
+        }
+        else // Object
+        {
+            py::dict obj;
+            for (nl::json::const_iterator it = j.cbegin(); it != j.cend(); ++it)
+            {
+                obj[py::str(it.key())] = from_json(it.value());
+            }
+            return std::move(obj);
+        }
+    }
+
+    inline nl::json to_json(const py::handle& obj)
+    {
+        if (obj.ptr() == nullptr || obj.is_none())
+        {
+            return nullptr;
+        }
+        if (py::isinstance<py::bool_>(obj))
+        {
+            return obj.cast<bool>();
+        }
+        if (py::isinstance<py::int_>(obj))
+        {
+            try
+            {
+                nl::json::number_integer_t s = obj.cast<nl::json::number_integer_t>();
+                if (py::int_(s).equal(obj))
+                {
+                    return s;
+                }
+            }
+            catch (...)
+            {
+            }
+            try
+            {
+                nl::json::number_unsigned_t u = obj.cast<nl::json::number_unsigned_t>();
+                if (py::int_(u).equal(obj))
+                {
+                    return u;
+                }
+            }
+            catch (...)
+            {
+            }
+            throw std::runtime_error("to_json received an integer out of range for both nl::json::number_integer_t and nl::json::number_unsigned_t type: " + py::repr(obj).cast<std::string>());
+        }
+        if (py::isinstance<py::float_>(obj))
+        {
+            return obj.cast<double>();
+        }
+        if (py::isinstance<py::bytes>(obj))
+        {
+            py::module base64 = py::module::import("base64");
+            return base64.attr("b64encode")(obj).attr("decode")("utf-8").cast<std::string>();
+        }
+        if (py::isinstance<py::str>(obj))
+        {
+            return obj.cast<std::string>();
+        }
+        if (py::isinstance<py::tuple>(obj) || py::isinstance<py::list>(obj))
+        {
+            auto out = nl::json::array();
+            for (const py::handle value : obj)
+            {
+                out.push_back(to_json(value));
+            }
+            return out;
+        }
+        if (py::isinstance<py::dict>(obj))
+        {
+            auto out = nl::json::object();
+            for (const py::handle key : obj)
+            {
+                out[py::str(key).cast<std::string>()] = to_json(obj[key]);
+            }
+            return out;
+        }
+        throw std::runtime_error("to_json not implemented for this type of object: " + py::repr(obj).cast<std::string>());
+    }
+}
+
+// nlohmann_json serializers
+namespace nlohmann
+{
+    #define MAKE_NLJSON_SERIALIZER_DESERIALIZER(T)         \
+    template <>                                            \
+    struct adl_serializer<T>                               \
+    {                                                      \
+        inline static void to_json(json& j, const T& obj)  \
+        {                                                  \
+            j = pyjson::to_json(obj);                      \
+        }                                                  \
+                                                           \
+        inline static T from_json(const json& j)           \
+        {                                                  \
+            return pyjson::from_json(j);                   \
+        }                                                  \
+    }
+
+    #define MAKE_NLJSON_SERIALIZER_ONLY(T)                 \
+    template <>                                            \
+    struct adl_serializer<T>                               \
+    {                                                      \
+        inline static void to_json(json& j, const T& obj)  \
+        {                                                  \
+            j = pyjson::to_json(obj);                      \
+        }                                                  \
+    }
+
+    MAKE_NLJSON_SERIALIZER_DESERIALIZER(py::object);
+
+    MAKE_NLJSON_SERIALIZER_DESERIALIZER(py::bool_);
+    MAKE_NLJSON_SERIALIZER_DESERIALIZER(py::int_);
+    MAKE_NLJSON_SERIALIZER_DESERIALIZER(py::float_);
+    MAKE_NLJSON_SERIALIZER_DESERIALIZER(py::str);
+
+    MAKE_NLJSON_SERIALIZER_DESERIALIZER(py::list);
+    MAKE_NLJSON_SERIALIZER_DESERIALIZER(py::tuple);
+    MAKE_NLJSON_SERIALIZER_DESERIALIZER(py::dict);
+
+    MAKE_NLJSON_SERIALIZER_ONLY(py::handle);
+    MAKE_NLJSON_SERIALIZER_ONLY(py::detail::item_accessor);
+    MAKE_NLJSON_SERIALIZER_ONLY(py::detail::list_accessor);
+    MAKE_NLJSON_SERIALIZER_ONLY(py::detail::tuple_accessor);
+    MAKE_NLJSON_SERIALIZER_ONLY(py::detail::sequence_accessor);
+    MAKE_NLJSON_SERIALIZER_ONLY(py::detail::str_attr_accessor);
+    MAKE_NLJSON_SERIALIZER_ONLY(py::detail::obj_attr_accessor);
+
+    #undef MAKE_NLJSON_SERIALIZER
+    #undef MAKE_NLJSON_SERIALIZER_ONLY
+}
+
+// pybind11 caster
+namespace pybind11
+{
+    namespace detail
+    {
+        template <> struct type_caster<nl::json>
+        {
+        public:
+            PYBIND11_TYPE_CASTER(nl::json, _("json"));
+
+            bool load(handle src, bool)
+            {
+                try
+                {
+                    value = pyjson::to_json(src);
+                    return true;
+                }
+                catch (...)
+                {
+                    return false;
+                }
+            }
+
+            static handle cast(nl::json src, return_value_policy /* policy */, handle /* parent */)
+            {
+                object obj = pyjson::from_json(src);
+                return obj.release();
+            }
+        };
+    }
+}
+
+#endif

--- a/test/scripts/test_flattener.py
+++ b/test/scripts/test_flattener.py
@@ -1,0 +1,27 @@
+import kafkaopmon
+import json
+import sys
+
+# Check that an argument was provided
+if len(sys.argv)<2:
+  print("Syntax: python python-flattener <json_file>")
+  quit()
+
+# Open and read JSON file
+file = sys.argv[1]
+f = open(file)
+
+j = json.load(f)
+
+print(j)
+
+print("------")
+
+# Flatten using bound function
+iqb = kafkaopmon.JsonFlattener(j)
+f = iqb.get()
+
+for field in f:
+   print(field)
+
+


### PR DESCRIPTION
Added python binding for the JsonFlattener class.

Uses pybind11_json.hpp from pybind/pybind11_json package. That package doesn't seem to be part of the release, but the header alone suffices for this. Flagging it up in case other packages need this in future, in which case including the package might be best.

Not done the macro references in the JsonFlattener header yet: pybind11 cannot bind macros, so if those are needed will need to write alternatives.