### PR TITLE
Enabling use for signature checking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,5 +35,4 @@ daq_add_unit_test( stream_OpMonFacility_test LINK_LIBRARIES kafkaopmon )
 daq_add_application( opmon_publisher_test opmon_publisher_test.cxx TEST LINK_LIBRARIES kafkaopmon )
 daq_add_application( opmon_publish_to_kafka_test opmon_publish_to_kafka_test.cxx TEST LINK_LIBRARIES kafkaopmon )
 
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/python/ DESTINATION ${CMAKE_INSTALL_PYTHONDIR} OPTIONAL FILES_MATCHING PATTERN "py.typed" PATTERN "*.pyi")
 daq_install()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,3 +36,4 @@ daq_add_application( opmon_publish_to_kafka_test opmon_publish_to_kafka_test.cxx
 
 daq_install()
 
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/python/ DESTINATION ${CMAKE_INSTALL_PYTHONDIR} OPTIONAL FILES_MATCHING PATTERN "py.typed" PATTERN "*.pyi")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(Boost COMPONENTS unit_test_framework program_options REQUIRED)
 
 daq_add_library(*.cpp LINK_LIBRARIES ${Boost_LIBRARIES} opmonlib::opmonlib RdKafka::rdkafka RdKafka::rdkafka++)
 
+
 ##############################################################################
 # Plugins
 
@@ -34,3 +35,4 @@ daq_add_application( opmon_publisher_test opmon_publisher_test.cxx TEST LINK_LIB
 daq_add_application( opmon_publish_to_kafka_test opmon_publish_to_kafka_test.cxx TEST LINK_LIBRARIES kafkaopmon )
 
 daq_install()
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/python/ DESTINATION ${CMAKE_INSTALL_PYTHONDIR} OPTIONAL FILES_MATCHING PATTERN "py.typed" PATTERN "*.pyi")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,6 @@ find_package(Boost COMPONENTS unit_test_framework program_options REQUIRED)
 
 daq_add_library(*.cpp LINK_LIBRARIES ${Boost_LIBRARIES} opmonlib::opmonlib RdKafka::rdkafka RdKafka::rdkafka++)
 
-daq_add_python_bindings(*.cpp)
-
 ##############################################################################
 # Plugins
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(Boost COMPONENTS unit_test_framework program_options REQUIRED)
 
 daq_add_library(*.cpp LINK_LIBRARIES ${Boost_LIBRARIES} opmonlib::opmonlib RdKafka::rdkafka RdKafka::rdkafka++)
 
+daq_add_python_bindings(*.cpp)
 
 ##############################################################################
 # Plugins
@@ -34,6 +35,5 @@ daq_add_unit_test( stream_OpMonFacility_test LINK_LIBRARIES kafkaopmon )
 daq_add_application( opmon_publisher_test opmon_publisher_test.cxx TEST LINK_LIBRARIES kafkaopmon )
 daq_add_application( opmon_publish_to_kafka_test opmon_publish_to_kafka_test.cxx TEST LINK_LIBRARIES kafkaopmon )
 
-daq_install()
-
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/python/ DESTINATION ${CMAKE_INSTALL_PYTHONDIR} OPTIONAL FILES_MATCHING PATTERN "py.typed" PATTERN "*.pyi")
+daq_install()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,3 +60,6 @@ lint.ignore = [
 ]
 src = ["python", "scripts"]
 lint.pydocstyle.convention = "google"
+
+[tool.setuptools.package-data]
+kafkaopmon = ["py.typed"]


### PR DESCRIPTION
# Description

In preparation for the resolution of https://github.com/DUNE-DAQ/drunc/issues/848, the `kafkaopmon` python source code needs to be available for checking of the signatures. To do this, a `py.typed` file is included, which is used to signal that the source python code is typed, with function signatures and return types specified for all functions.


_Please also include instructions for how a reviewer can test your changes._


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [X] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [X] Unit tests pass (e.g. `dbt-build --unittest`)
- [X] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [X] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [X] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

